### PR TITLE
Do not use basic access authentication

### DIFF
--- a/internal/server/box/box.go
+++ b/internal/server/box/box.go
@@ -1,0 +1,69 @@
+package box
+
+import (
+	cryptorand "crypto/rand"
+	"github.com/golang-jwt/jwt/v5"
+	"time"
+)
+
+const validityDuration = 5 * time.Minute
+
+type Manager struct {
+	key []byte
+}
+
+type Box struct {
+	CacheKeyPrefix string `json:"ckp,omitempty"`
+}
+
+type claims struct {
+	Box
+
+	jwt.RegisteredClaims
+}
+
+func NewManager() (*Manager, error) {
+	key := make([]byte, 32)
+
+	_, err := cryptorand.Read(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		key: key,
+	}, nil
+}
+
+func (manager *Manager) Seal(box Box) (string, error) {
+	now := time.Now()
+
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims{
+		Box: box,
+		RegisteredClaims: jwt.RegisteredClaims{
+			NotBefore: jwt.NewNumericDate(now.Add(-validityDuration)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(validityDuration)),
+		},
+	})
+
+	return jwtToken.SignedString(manager.key)
+}
+
+func (manager *Manager) Unseal(sealedBox string) (Box, error) {
+	var claims claims
+
+	validMethods := []string{
+		jwt.SigningMethodHS256.Alg(),
+	}
+
+	_, err := jwt.ParseWithClaims(sealedBox, &claims, manager.keyFunc, jwt.WithValidMethods(validMethods))
+	if err != nil {
+		return Box{}, err
+	}
+
+	return claims.Box, nil
+}
+
+func (manager *Manager) keyFunc(_ *jwt.Token) (interface{}, error) {
+	return manager.key, nil
+}

--- a/internal/server/box/box_test.go
+++ b/internal/server/box/box_test.go
@@ -1,0 +1,25 @@
+package box_test
+
+import (
+	"github.com/cirruslabs/chacha/internal/server/box"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	manager, err := box.NewManager()
+	require.NoError(t, err)
+
+	expectedBox := box.Box{
+		CacheKeyPrefix: uuid.NewString(),
+	}
+
+	sealedBox, err := manager.Seal(expectedBox)
+	require.NoError(t, err)
+
+	unsealedBox, err := manager.Unseal(sealedBox)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedBox, unsealedBox)
+}


### PR DESCRIPTION
Action Toolkit, unfortunately, [manually craft their own HTTP request](https://github.com/actions/toolkit/blob/ff435e591d8adcef0ed2c17c28a42430d5ddd900/packages/http-client/src/index.ts#L580-L615), omitting the basic access authentication credentials that may be present in the URL returned in the GHA cache protocol.

So, the only way to pass credentials seems to be using URL's query parameters, but to avoid exposing the OIDC token trusted to us in the URL's query, generate our own short-lived JWT token for these purposes.