### PR TITLE
macOS "Local Network" permission helper to enable LAN communication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.11.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sys v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -46,7 +47,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/net v0.36.0 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect

--- a/internal/cache/kv/kv.go
+++ b/internal/cache/kv/kv.go
@@ -9,15 +9,28 @@ import (
 )
 
 type KV struct {
-	node   string
-	secret string
+	node       string
+	secret     string
+	httpClient *http.Client
 }
 
-func New(node string, secret string) *KV {
-	return &KV{
+func New(node string, secret string, opts ...Option) *KV {
+	kv := &KV{
 		node:   node,
 		secret: secret,
 	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(kv)
+	}
+
+	// Apply defaults
+	if kv.httpClient == nil {
+		kv.httpClient = http.DefaultClient
+	}
+
+	return kv
 }
 
 func (kv *KV) Node() string {
@@ -44,7 +57,7 @@ func (kv *KV) Get(
 	}
 
 	// Perform request
-	response, err := http.DefaultClient.Do(request)
+	response, err := kv.httpClient.Do(request)
 	if err != nil {
 		return nil, cachepkg.Metadata{}, err
 	}
@@ -97,7 +110,7 @@ func (kv *KV) Put(
 	}
 
 	// Perform request
-	response, err := http.DefaultClient.Do(request)
+	response, err := kv.httpClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/internal/cache/kv/option.go
+++ b/internal/cache/kv/option.go
@@ -1,0 +1,11 @@
+package kv
+
+import "net/http"
+
+type Option func(kv *KV)
+
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(kv *KV) {
+		kv.httpClient = httpClient
+	}
+}

--- a/internal/command/localnetworkhelper/localnetworkhelper.go
+++ b/internal/command/localnetworkhelper/localnetworkhelper.go
@@ -1,0 +1,29 @@
+package localnetworkhelper
+
+import (
+	"github.com/cirruslabs/chacha/pkg/localnetworkhelper"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    localnetworkhelper.CommandName,
+		Short:  "Run the macOS \"Local Network\" permission helper process",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// In localnetworkhelper.New(), a macOS "Local Network"
+			// permission helper process is spawned and receives
+			// its socketpair(2) end via ExtraFiles field of Golang's
+			// exec.Cmd[1].
+			//
+			// This socketpair(2) end becomes FD number 3 here,
+			// according to the ExtraFiles documentation[1]:
+			//
+			// >If non-nil, entry i becomes file descriptor 3+i.
+			//
+			// [1]: https://pkg.go.dev/os/exec#Cmd
+			return localnetworkhelper.Serve(cmd.Context(), 3)
+		},
+	}
+	return cmd
+}

--- a/internal/command/localnetworkhelper/localnetworkhelper.go
+++ b/internal/command/localnetworkhelper/localnetworkhelper.go
@@ -22,7 +22,7 @@ func NewCommand() *cobra.Command {
 			// >If non-nil, entry i becomes file descriptor 3+i.
 			//
 			// [1]: https://pkg.go.dev/os/exec#Cmd
-			return localnetworkhelper.Serve(cmd.Context(), 3)
+			return localnetworkhelper.Serve(3)
 		},
 	}
 	return cmd

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"github.com/cirruslabs/chacha/internal/command/localnetworkhelper"
 	"github.com/cirruslabs/chacha/internal/command/run"
 	"github.com/cirruslabs/chacha/internal/logginglevel"
 	"github.com/cirruslabs/chacha/internal/version"
@@ -30,6 +31,7 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.AddCommand(
 		run.NewCommand(),
+		localnetworkhelper.NewCommand(),
 	)
 
 	return cmd

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cirruslabs/chacha/internal/server/cluster"
 	"github.com/cirruslabs/chacha/internal/server/rule"
 	"github.com/cirruslabs/chacha/internal/server/tlsinterceptor"
+	"github.com/cirruslabs/chacha/pkg/localnetworkhelper"
 	"go.uber.org/zap"
 )
 
@@ -31,6 +32,12 @@ func WithRules(rules rule.Rules) Option {
 func WithCluster(cluster *cluster.Cluster) Option {
 	return func(server *Server) {
 		server.cluster = cluster
+	}
+}
+
+func WithLocalNetworkHelper(localNetworkHelper *localnetworkhelper.LocalNetworkHelper) Option {
+	return func(server *Server) {
+		server.localNetworkHelper = localNetworkHelper
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	responderpkg "github.com/cirruslabs/chacha/internal/server/responder"
 	"github.com/cirruslabs/chacha/internal/server/rule"
 	"github.com/cirruslabs/chacha/internal/server/tlsinterceptor"
+	"github.com/cirruslabs/chacha/pkg/localnetworkhelper"
 	"github.com/im7mortal/kmutex"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -29,10 +30,11 @@ type Server struct {
 	kmutex     *kmutex.Kmutex
 	logger     *zap.SugaredLogger
 
-	disk           cachepkg.Cache
-	tlsInterceptor *tlsinterceptor.TLSInterceptor
-	rules          rule.Rules
-	cluster        *cluster.Cluster
+	disk               cachepkg.Cache
+	tlsInterceptor     *tlsinterceptor.TLSInterceptor
+	rules              rule.Rules
+	cluster            *cluster.Cluster
+	localNetworkHelper *localnetworkhelper.LocalNetworkHelper
 
 	// Metrics
 	requestsCounter       metric.Int64Counter

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -153,5 +153,11 @@ func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
 		return nil, err
 	}
 
+	// We can safely close the unixRights[0] now
+	// that it was dup(2)'ed by the net.FileConn
+	if err := unix.Close(unixRights[0]); err != nil {
+		return nil, err
+	}
+
 	return netConn, nil
 }

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -1,0 +1,157 @@
+package localnetworkhelper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+const CommandName = "localnetworkhelper"
+
+type PrivilegedSocketRequest struct {
+	Network string `json:"network"`
+	Addr    string `json:"addr"`
+}
+
+type PrivilegedSocketResponse struct {
+	Error string `json:"error"`
+}
+
+type LocalNetworkHelper struct {
+	unixConn *net.UnixConn
+
+	mtx sync.Mutex
+}
+
+// New starts a privileged part of the macOS "Local Network" permission
+// helper as a child process and enables communication with it.
+func New(ctx context.Context) (*LocalNetworkHelper, error) {
+	// Create a socketpair(2) for communicating with the helper process
+	socketPair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Launch our executable as a child process
+	//
+	// We're specifying the CommandName argument,
+	// so that the child will jump to Serve()
+	// and will wait for us.
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, executable, CommandName)
+
+	cmd.ExtraFiles = []*os.File{
+		os.NewFile(uintptr(socketPair[1]), ""),
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	cmd.WaitDelay = time.Second
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		if err := cmd.Wait(); !errors.Is(ctx.Err(), context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	// Convert our end of the socketpair(2) to a *unix.Conn
+	conn, err := net.FileConn(os.NewFile(uintptr(socketPair[0]), ""))
+	if err != nil {
+		return nil, err
+	}
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("expected *net.UnixConn, got %T", conn)
+	}
+
+	return &LocalNetworkHelper{
+		unixConn: unixConn,
+	}, nil
+}
+
+func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
+	ctx context.Context,
+	network string,
+	addr string,
+) (net.Conn, error) {
+	// Prevent concurrency to avoid intermixing requests and responses
+	localNetworkHelper.mtx.Lock()
+	defer localNetworkHelper.mtx.Unlock()
+
+	privilegedSocketRequest := PrivilegedSocketRequest{
+		Network: network,
+		Addr:    addr,
+	}
+
+	privilegedSocketRequestJSONBytes, err := json.Marshal(&privilegedSocketRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = localNetworkHelper.unixConn.Write(privilegedSocketRequestJSONBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 4096)
+	oob := make([]byte, 4096)
+
+	n, oobn, _, _, err := localNetworkHelper.unixConn.ReadMsgUnix(buf, oob)
+	if err != nil {
+		return nil, err
+	}
+
+	var privilegedSocketResponse PrivilegedSocketResponse
+
+	if err := json.Unmarshal(buf[:n], &privilegedSocketResponse); err != nil {
+		return nil, err
+	}
+
+	if privilegedSocketResponse.Error != "" {
+		return nil, fmt.Errorf("%s", privilegedSocketResponse.Error)
+	}
+
+	socketControlMessages, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return nil, err
+	}
+
+	if len(socketControlMessages) != 1 {
+		return nil, fmt.Errorf("expected exactly one socket control message, got %d", len(socketControlMessages))
+	}
+
+	unixRights, err := unix.ParseUnixRights(&socketControlMessages[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse unix rights: %w", err)
+	}
+
+	if len(unixRights) != 1 {
+		return nil, fmt.Errorf("expected exactly one unix right, got %d", len(unixRights))
+	}
+
+	netFile := os.NewFile(uintptr(unixRights[0]), "")
+
+	netConn, err := net.FileConn(netFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return netConn, nil
+}

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -78,7 +78,7 @@ func New(ctx context.Context) (*LocalNetworkHelper, error) {
 	}
 
 	go func() {
-		if err := cmd.Wait(); !errors.Is(ctx.Err(), context.Canceled) {
+		if err := cmd.Wait(); err != nil && !errors.Is(ctx.Err(), context.Canceled) {
 			panic(err)
 		}
 	}()

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -15,9 +15,11 @@ func TestMain(m *testing.M) {
 		if err := localnetworkhelper.Serve(context.Background(), 3); err != nil {
 			panic(err)
 		}
-	}
 
-	m.Run()
+		os.Exit(0)
+	} else {
+		os.Exit(m.Run())
+	}
 }
 
 func TestLocalNetworkHelper(t *testing.T) {

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMain(m *testing.M) {
 	if len(os.Args) == 2 && os.Args[1] == "localnetworkhelper" {
-		if err := localnetworkhelper.Serve(context.Background(), 3); err != nil {
+		if err := localnetworkhelper.Serve(3); err != nil {
 			panic(err)
 		}
 

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -1,0 +1,45 @@
+package localnetworkhelper_test
+
+import (
+	"context"
+	"github.com/cirruslabs/chacha/pkg/localnetworkhelper"
+	"github.com/stretchr/testify/require"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if len(os.Args) == 2 && os.Args[1] == "localnetworkhelper" {
+		if err := localnetworkhelper.Serve(context.Background(), 3); err != nil {
+			panic(err)
+		}
+	}
+
+	m.Run()
+}
+
+func TestLocalNetworkHelper(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	localNetworkHelper, err := localnetworkhelper.New(ctx)
+	require.NoError(t, err)
+
+	privilegedConn, err := localNetworkHelper.PrivilegedDialContext(ctx, "tcp", "example.com:443")
+	require.NoError(t, err)
+	require.IsType(t, &net.TCPConn{}, privilegedConn)
+
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return privilegedConn, nil
+			},
+		},
+	}
+
+	resp, err := httpClient.Get("https://example.com/")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/pkg/localnetworkhelper/serve.go
+++ b/pkg/localnetworkhelper/serve.go
@@ -21,6 +21,11 @@ func Serve(fd int) error {
 		return err
 	}
 
+	// We can safely close the fd now as it was dup(2)'ed by the net.FileConn
+	if err := unix.Close(fd); err != nil {
+		return err
+	}
+
 	unixConn, ok := conn.(*net.UnixConn)
 	if !ok {
 		return fmt.Errorf("expected *net.UnixConn, got %T", conn)

--- a/pkg/localnetworkhelper/serve.go
+++ b/pkg/localnetworkhelper/serve.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"golang.org/x/sys/unix"
+	"io"
 	"net"
 	"os"
 	"syscall"
@@ -46,6 +47,10 @@ func Serve(ctx context.Context, fd int) error {
 
 		n, err := unixConn.Read(buf)
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+
 			var netError net.Error
 
 			if errors.As(err, &netError) && netError.Timeout() {

--- a/pkg/localnetworkhelper/serve.go
+++ b/pkg/localnetworkhelper/serve.go
@@ -1,0 +1,99 @@
+package localnetworkhelper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"net"
+	"os"
+	"time"
+)
+
+// Serve implements a privileged component of the macOS "Local Network" permission helper.
+//
+// It listens for net.Dial requests, performs the dialing and sends the results back.
+func Serve(ctx context.Context, fd int) error {
+	// Convert our end of the socketpair(2) to a *unix.Conn
+	conn, err := net.FileConn(os.NewFile(uintptr(fd), ""))
+	if err != nil {
+		return err
+	}
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("expected *net.UnixConn, got %T", conn)
+	}
+
+	// Serve requests
+	buf := make([]byte, 4096)
+
+	for {
+		// Check for context cancellation
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			// Proceed with serving
+		}
+
+		// Do not block, periodically check for context cancellation
+		if err := unixConn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+			return err
+		}
+
+		n, err := unixConn.Read(buf)
+		if err != nil {
+			var netError net.Error
+
+			if errors.As(err, &netError) && netError.Timeout() {
+				continue
+			}
+
+			return err
+		}
+
+		var privilegedSocketRequest PrivilegedSocketRequest
+
+		if err := json.Unmarshal(buf[:n], &privilegedSocketRequest); err != nil {
+			return err
+		}
+
+		var privilegedSocketResponse PrivilegedSocketResponse
+		var oob []byte
+
+		netConn, err := net.Dial(privilegedSocketRequest.Network, privilegedSocketRequest.Addr)
+		if err != nil {
+			privilegedSocketResponse.Error = err.Error()
+		} else {
+			var netFile *os.File
+
+			switch typedNetConn := netConn.(type) {
+			case *net.TCPConn:
+				netFile, err = typedNetConn.File()
+			case *net.UDPConn:
+				netFile, err = typedNetConn.File()
+			default:
+				err = fmt.Errorf("unsupported net.Conn type: %T", netConn)
+			}
+			if err != nil {
+				privilegedSocketResponse.Error = err.Error()
+			}
+
+			if netFile != nil {
+				oob = unix.UnixRights(int(netFile.Fd()))
+			}
+		}
+
+		privilegedSocketResponseJSONBytes, err := json.Marshal(privilegedSocketResponse)
+		if err != nil {
+			return err
+		}
+
+		_, _, err = unixConn.WriteMsgUnix(privilegedSocketResponseJSONBytes, oob, nil)
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/privdrop/privdrop.go
+++ b/pkg/privdrop/privdrop.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package privdrop
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+	userpkg "os/user"
+	"strconv"
+)
+
+var ErrFailed = errors.New("failed to drop privileges")
+
+func Drop(username string) error {
+	user, err := userpkg.Lookup(username)
+	if err != nil {
+		return fmt.Errorf("%w: failed to lookup username %q: %v",
+			ErrFailed, username, err)
+	}
+
+	gid, err := strconv.Atoi(user.Gid)
+	if err != nil {
+		return fmt.Errorf("%w: failed to parse %s's group ID %q: %v",
+			ErrFailed, user.Name, user.Gid, err)
+	}
+
+	if err := unix.Setregid(gid, gid); err != nil {
+		return fmt.Errorf("%w: failed to set real and effective group ID to %d: %v",
+			ErrFailed, gid, err)
+	}
+
+	if err := os.Setenv("HOME", user.HomeDir); err != nil {
+		return fmt.Errorf("%w: failed to set new HOME to %q: %v",
+			ErrFailed, user.HomeDir, err)
+	}
+
+	uid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		return fmt.Errorf("%w: failed to parse %s's user ID %q: %v",
+			ErrFailed, user.Name, user.Uid, err)
+	}
+
+	if err := unix.Setreuid(uid, uid); err != nil {
+		return fmt.Errorf("%w: failed to set real and effective user ID to %d: %v",
+			ErrFailed, uid, err)
+	}
+
+	return nil
+}

--- a/pkg/privdrop/privdrop_unsupported.go
+++ b/pkg/privdrop/privdrop_unsupported.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package privdrop
+
+import "fmt"
+
+func Drop(username string) error {
+	return fmt.Errorf("privilege dropping is not implemented on this platform")
+}


### PR DESCRIPTION
Currently with Chacha on macOS Sequoia we get this error:

```
cluster node [...] is not available: Get "http://[...]": dial tcp [...]: connect: no route to host
```

This proposes a more simplified approach to https://github.com/cirruslabs/cirrus-cli/pull/814: we now simply pass file descriptors instead of doing the proxying.

If this works well enough, it's possible to reuse this mechanism of working around the macOS Sequoia "Local Network" permissions for Cirrus CLI and Orchard.