### PR TITLE
Do not close(2) file descriptors passed to os.NewFile()

### DIFF
--- a/pkg/localnetworkhelper/serve.go
+++ b/pkg/localnetworkhelper/serve.go
@@ -16,13 +16,15 @@ import (
 // It listens for net.Dial requests, performs the dialing and sends the results back.
 func Serve(fd int) error {
 	// Convert our end of the socketpair(2) to a *unix.Conn
-	conn, err := net.FileConn(os.NewFile(uintptr(fd), ""))
+	file := os.NewFile(uintptr(fd), "")
+
+	conn, err := net.FileConn(file)
 	if err != nil {
 		return err
 	}
 
 	// We can safely close the fd now as it was dup(2)'ed by the net.FileConn
-	if err := unix.Close(fd); err != nil {
+	if err := file.Close(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
It messes up with Golang runtime and results in unavailable HTTP server.

Instead, call `Close()` on `*os.File` returned from `os.NewFile()`.