### PR TITLE
Disable compression when making HTTP requests

### DIFF
--- a/internal/server/handle_proxy_default.go
+++ b/internal/server/handle_proxy_default.go
@@ -111,7 +111,7 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 	server.logger.Debugf("upstream request: %+v", upstreamRequest)
 
 	// Perform an upstream request
-	upstreamResponse, err := http.DefaultClient.Do(upstreamRequest)
+	upstreamResponse, err := server.httpClient.Do(upstreamRequest)
 	if err != nil {
 		return responder.NewCodef(http.StatusInternalServerError, "failed to perform a request "+
 			"to the upstream: %v", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 type Server struct {
 	listener   net.Listener
 	httpServer *http.Server
+	httpClient *http.Client
 	kmutex     *kmutex.Kmutex
 	logger     *zap.SugaredLogger
 
@@ -44,6 +45,11 @@ type Server struct {
 
 func New(addr string, opts ...Option) (*Server, error) {
 	server := &Server{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				DisableCompression: true,
+			},
+		},
 		kmutex: kmutex.New(),
 	}
 


### PR DESCRIPTION
Without this change, Golang's HTTP client used in Chacha will transparently decode e.g. a `Content-Encoding: gzip` response and [will strip the header](https://github.com/golang/go/blob/b9cbb65384f6bebd58f7a8354759b8c7b1bbb13f/src/net/http/response.go#L89-L96).

This complicates `Vary` header handling (which we currently just treat as non-cacheable, but might support properly at some point) and imposes extra computation costs on the proxy.