### PR TITLE
localnetworkhelper: support context.Context and avoid using sync.Mutex

### DIFF
--- a/internal/command/localnetworkhelper/localnetworkhelper.go
+++ b/internal/command/localnetworkhelper/localnetworkhelper.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package localnetworkhelper
 
 import (

--- a/internal/command/localnetworkhelper/localnetworkhelper_unsupported.go
+++ b/internal/command/localnetworkhelper/localnetworkhelper_unsupported.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package localnetworkhelper
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	return nil
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -29,10 +29,15 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
 
-	cmd.AddCommand(
+	commands := []*cobra.Command{
 		run.NewCommand(),
-		localnetworkhelper.NewCommand(),
-	)
+	}
+
+	if localNetworkHelperCommand := localnetworkhelper.NewCommand(); localNetworkHelperCommand != nil {
+		commands = append(commands, localNetworkHelperCommand)
+	}
+
+	cmd.AddCommand(commands...)
 
 	return cmd
 }

--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"os"
+	"runtime"
 )
 
 var configPath string
@@ -29,8 +30,11 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&configPath, "file", "f", "",
 		"configuration file path (e.g. /etc/chacha.yml)")
-	cmd.Flags().StringVar(&username, "user", "",
-		"username to drop privileges to")
+
+	if runtime.GOOS == "darwin" {
+		cmd.Flags().StringVar(&username, "user", "",
+			"username to drop privileges to")
+	}
 
 	return cmd
 }

--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -43,10 +43,11 @@ func run(cmd *cobra.Command, _ []string) error {
 	// Run the macOS "Local Network" permission helper
 	// when privilege dropping is requested
 	if username != "" {
-		localNetworkHelper, err := localnetworkhelper.New(cmd.Context())
+		localNetworkHelper, err := localnetworkhelper.New(cmd.Context(), "", "chacha-*")
 		if err != nil {
 			return err
 		}
+		defer localNetworkHelper.Close()
 
 		opts = append(opts, serverpkg.WithLocalNetworkHelper(localNetworkHelper))
 

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -5,15 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/samber/lo"
 	"golang.org/x/sys/unix"
 	"net"
 	"os"
 	"os/exec"
-	"sync"
+	"path/filepath"
 	"time"
 )
 
-const CommandName = "localnetworkhelper"
+const (
+	CommandName = "localnetworkhelper"
+
+	socketName = "localnetworkhelper.sock"
+)
 
 type PrivilegedSocketRequest struct {
 	Network string `json:"network"`
@@ -25,31 +30,22 @@ type PrivilegedSocketResponse struct {
 }
 
 type LocalNetworkHelper struct {
-	unixConn *net.UnixConn
-
-	mtx sync.Mutex
+	tmpDir string
 }
 
 // New starts a privileged part of the macOS "Local Network" permission
 // helper as a child process and enables communication with it.
-func New(ctx context.Context) (*LocalNetworkHelper, error) {
-	// Create a socketpair(2) for communicating with the helper process
-	socketPair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+func New(ctx context.Context, dir string, pattern string) (*LocalNetworkHelper, error) {
+	socketDir, err := os.MkdirTemp(dir, pattern)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set FD_CLOEXEC to prevent file descriptor leakage to the child process
-	//
-	// Golang normally sets this flag when using higher-level OS functions,
-	// but this is not the case with unix/syscall packages.
-	//
-	// See https://github.com/golang/go/issues/37857#issuecomment-599174378 for more details.
-	if _, err := unix.FcntlInt(uintptr(socketPair[0]), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
-		return nil, fmt.Errorf("failed to set FD_CLOEXEC on a first socketpair(2) socket: %v", err)
-	}
-	if _, err := unix.FcntlInt(uintptr(socketPair[1]), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
-		return nil, fmt.Errorf("failed to set FD_CLOEXEC on a second socketpair(2) socket: %v", err)
+	unixSocket, err := net.ListenUnix("unix", &net.UnixAddr{
+		Name: filepath.Join(socketDir, socketName),
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// Launch our executable as a child process
@@ -64,10 +60,13 @@ func New(ctx context.Context) (*LocalNetworkHelper, error) {
 
 	cmd := exec.CommandContext(ctx, executable, CommandName)
 
-	extraFile := os.NewFile(uintptr(socketPair[1]), "")
+	chachaUnixFile, err := unixSocket.File()
+	if err != nil {
+		return nil, err
+	}
 
 	cmd.ExtraFiles = []*os.File{
-		extraFile,
+		chachaUnixFile,
 	}
 
 	cmd.Stdout = os.Stdout
@@ -79,8 +78,10 @@ func New(ctx context.Context) (*LocalNetworkHelper, error) {
 		return nil, err
 	}
 
-	// We can safely close the socketPair[1] now as it was inherited by the child
-	if err := extraFile.Close(); err != nil {
+	// We can safely close the unixSocket now as it was inherited by the child
+	unixSocket.SetUnlinkOnClose(false)
+
+	if err := unixSocket.Close(); err != nil {
 		return nil, err
 	}
 
@@ -90,26 +91,8 @@ func New(ctx context.Context) (*LocalNetworkHelper, error) {
 		}
 	}()
 
-	// Convert our end of the socketpair(2) to a *unix.Conn
-	file := os.NewFile(uintptr(socketPair[0]), "")
-
-	conn, err := net.FileConn(file)
-	if err != nil {
-		return nil, err
-	}
-
-	// We can safely close the socketPair[0] now as it was dup(2)'ed by the net.FileConn
-	if err := file.Close(); err != nil {
-		return nil, err
-	}
-
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return nil, fmt.Errorf("expected *net.UnixConn, got %T", conn)
-	}
-
 	return &LocalNetworkHelper{
-		unixConn: unixConn,
+		tmpDir: socketDir,
 	}, nil
 }
 
@@ -118,9 +101,18 @@ func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
 	network string,
 	addr string,
 ) (net.Conn, error) {
-	// Prevent concurrency to avoid intermixing requests and responses
-	localNetworkHelper.mtx.Lock()
-	defer localNetworkHelper.mtx.Unlock()
+	dialer := &net.Dialer{}
+
+	conn, err := dialer.DialContext(ctx, "unix", filepath.Join(localNetworkHelper.tmpDir, socketName))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("expected *net.UnixConn, got %T", conn)
+	}
 
 	privilegedSocketRequest := PrivilegedSocketRequest{
 		Network: network,
@@ -132,17 +124,43 @@ func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
 		return nil, err
 	}
 
-	_, err = localNetworkHelper.unixConn.Write(privilegedSocketRequestJSONBytes)
-	if err != nil {
-		return nil, err
+	// Send request
+	writeResultCh := make(chan lo.Tuple2[int, error], 1)
+
+	go func() {
+		writeResultCh <- lo.T2(unixConn.Write(privilegedSocketRequestJSONBytes))
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-writeResultCh:
+		_, err := lo.Unpack2(result)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	buf := make([]byte, 4096)
 	oob := make([]byte, 4096)
 
-	n, oobn, _, _, err := localNetworkHelper.unixConn.ReadMsgUnix(buf, oob)
-	if err != nil {
-		return nil, err
+	// Receive response
+	readMsgUnixResultCh := make(chan lo.Tuple5[int, int, int, *net.UnixAddr, error], 1)
+
+	go func() {
+		readMsgUnixResultCh <- lo.T5(unixConn.ReadMsgUnix(buf, oob))
+	}()
+
+	var n, oobn int
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-readMsgUnixResultCh:
+		n, oobn, _, _, err = lo.Unpack5(result)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var privilegedSocketResponse PrivilegedSocketResponse
@@ -186,4 +204,8 @@ func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
 	}
 
 	return netConn, nil
+}
+
+func (localNetworkHelper *LocalNetworkHelper) Close() error {
+	return os.RemoveAll(localNetworkHelper.tmpDir)
 }

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -8,7 +8,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -27,7 +29,7 @@ func TestLocalNetworkHelper(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	localNetworkHelper, err := localnetworkhelper.New(ctx)
+	localNetworkHelper, err := localnetworkhelper.New(ctx, "", "chacha-*")
 	require.NoError(t, err)
 
 	httpClient := http.Client{
@@ -42,19 +44,69 @@ func TestLocalNetworkHelper(t *testing.T) {
 		},
 	}
 
-	respExample, err := httpClient.Get("https://example.com/")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, respExample.StatusCode)
+	var wg sync.WaitGroup
 
-	respCirrus, err := httpClient.Get("https://cirrus-ci.org/")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, respCirrus.StatusCode)
+	wg.Add(3)
 
-	exampleBytes, err := io.ReadAll(respExample.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(exampleBytes), "Example Domain")
+	go func() {
+		defer wg.Done()
 
-	cirrusBytes, err := io.ReadAll(respCirrus.Body)
+		respExample, err := httpClient.Get("https://example.com/")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respExample.StatusCode)
+
+		exampleBytes, err := io.ReadAll(respExample.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(exampleBytes), "Example Domain")
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		respCirrus, err := httpClient.Get("https://cirrus-ci.org/")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respCirrus.StatusCode)
+
+		cirrusBytes, err := io.ReadAll(respCirrus.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(cirrusBytes), "Cirrus CI")
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		respCirrus, err := httpClient.Get("https://cirrus-runners.app/")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respCirrus.StatusCode)
+
+		cirrusBytes, err := io.ReadAll(respCirrus.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(cirrusBytes), "Cirrus Runners")
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, localNetworkHelper.Close())
+}
+
+func TestLocalNetworkHelperRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	localNetworkHelper, err := localnetworkhelper.New(ctx, "", "chacha-*")
 	require.NoError(t, err)
-	require.Contains(t, string(cirrusBytes), "Cirrus CI")
+
+	boundedCtx, boundedCtxCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer boundedCtxCancel()
+
+	startedAt := time.Now()
+
+	// Try to connect to an address in non-routable TEST-NET-1[1]
+	//
+	// [1]: https://datatracker.ietf.org/doc/html/rfc5737#section-3
+	_, err = localNetworkHelper.PrivilegedDialContext(boundedCtx, "tcp", "192.0.2.1:80")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.InDelta(t, 3.0, time.Since(startedAt).Seconds(), 0.5)
+
+	require.NoError(t, localNetworkHelper.Close())
 }

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package localnetworkhelper_test
 
 import (


### PR DESCRIPTION
Currently `localnetworkhelper` uses a single connection provided by `socketpair(2)`.

This change instead switches to a UNIX domain socket between the `localnetworkhelper` and its consumer.

With a true client-server model, we can unlock the parallelism and support `context.Context` in `PrivilegedDialContext()` without the extra complexity of bookkeeping which requests correspond to which responses.

This should increase robustness in presence of long DNS resolutions and in cases of high consumer contention, and hopefully make it a more viable option to try in Orchard and Cirrus CLI, which are in need of a more secure way of working around "Local Network" permission in macOS Sequoia.