### PR TITLE
localnetworkhelper: ensure permissions on a socket allow incoming conns.

### DIFF
--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -41,10 +41,18 @@ func New(ctx context.Context, dir string, pattern string) (*LocalNetworkHelper, 
 		return nil, err
 	}
 
+	if err := os.Chmod(socketDir, 0755); err != nil {
+		return nil, err
+	}
+
 	unixSocket, err := net.ListenUnix("unix", &net.UnixAddr{
 		Name: filepath.Join(socketDir, socketName),
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Chmod(filepath.Join(socketDir, socketName), 0777); err != nil {
 		return nil, err
 	}
 

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, dir string, pattern string) (*LocalNetworkHelper, 
 	}
 
 	if err := os.Chmod(socketDir, 0755); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to set permissions on socket directory: %w", err)
 	}
 
 	unixSocket, err := net.ListenUnix("unix", &net.UnixAddr{
@@ -53,7 +53,7 @@ func New(ctx context.Context, dir string, pattern string) (*LocalNetworkHelper, 
 	}
 
 	if err := os.Chmod(filepath.Join(socketDir, socketName), 0777); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to set permissions on socket: %w", err)
 	}
 
 	// Launch our executable as a child process


### PR DESCRIPTION
https://man7.org/linux/man-pages/man7/unix.7.html:

>On Linux, connecting to a stream socket object requires write permission on that socket

...similar on Darwin.