### PR TITLE
Unlock localnetworkhelper and obey ctx in PrivilegedDialContext()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/cirruslabs/chacha
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.5
+toolchain go1.24.2
 
 require (
 	github.com/dustin/go-humanize v1.0.1
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/im7mortal/kmutex v1.0.2
 	github.com/nspcc-dev/hrw/v2 v2.0.3
+	github.com/puzpuzpuz/xsync/v4 v4.0.0
 	github.com/samber/lo v1.39.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/nspcc-dev/hrw/v2 v2.0.3 h1:GUIitIiDpAaQat9SZccp7XVAuwtqaM40+uZ9D8Q4A8
 github.com/nspcc-dev/hrw/v2 v2.0.3/go.mod h1:VWlFSGGPcHG1abuIDJb5u83tIF2EqOatC8Z7svZmgWQ=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/puzpuzpuz/xsync/v4 v4.0.0 h1:F1za+MBXzDQtQq+OVgFsojSX4w66rsNDmQNebPFAncA=
+github.com/puzpuzpuz/xsync/v4 v4.0.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -1,39 +1,65 @@
 package localnetworkhelper
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
+	"github.com/puzpuzpuz/xsync/v4"
 	"golang.org/x/sys/unix"
+	"io"
 	"net"
 	"os"
 	"os/exec"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
 const CommandName = "localnetworkhelper"
 
 type PrivilegedSocketRequest struct {
+	Token   string `json:"token"`
 	Network string `json:"network"`
 	Addr    string `json:"addr"`
 }
 
 type PrivilegedSocketResponse struct {
+	Token string `json:"token"`
 	Error string `json:"error"`
 }
 
-type LocalNetworkHelper struct {
-	unixConn *net.UnixConn
+type Request struct {
+	Network string
+	Addr    string
+	ReplyCh chan Reply
+}
 
-	mtx sync.Mutex
+type Reply struct {
+	Conn net.Conn
+	Err  error
+}
+
+type LocalNetworkHelper struct {
+	unixConn            *net.UnixConn
+	requestsUnprocessed chan Request
+	requestsProcessed   *xsync.Map[string, Request]
+	err                 atomic.Pointer[error]
 }
 
 // New starts a privileged part of the macOS "Local Network" permission
 // helper as a child process and enables communication with it.
 func New(ctx context.Context) (*LocalNetworkHelper, error) {
+	localNetworkHelper := &LocalNetworkHelper{
+		requestsUnprocessed: make(chan Request),
+		requestsProcessed:   xsync.NewMap[string, Request](),
+	}
+
 	// Create a socketpair(2) for communicating with the helper process
+	//
+	// We could've used datagram socket to simplify message boundary handling,
+	// but that would make the connection close detection impossible.
 	socketPair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
 	if err != nil {
 		return nil, err
@@ -86,7 +112,7 @@ func New(ctx context.Context) (*LocalNetworkHelper, error) {
 
 	go func() {
 		if err := cmd.Wait(); err != nil && !errors.Is(ctx.Err(), context.Canceled) {
-			panic(err)
+			localNetworkHelper.err.CompareAndSwap(nil, &err)
 		}
 	}()
 
@@ -107,10 +133,12 @@ func New(ctx context.Context) (*LocalNetworkHelper, error) {
 	if !ok {
 		return nil, fmt.Errorf("expected *net.UnixConn, got %T", conn)
 	}
+	localNetworkHelper.unixConn = unixConn
 
-	return &LocalNetworkHelper{
-		unixConn: unixConn,
-	}, nil
+	go localNetworkHelper.handleRequests()
+	go localNetworkHelper.handleResponses()
+
+	return localNetworkHelper, nil
 }
 
 func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
@@ -118,46 +146,123 @@ func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
 	network string,
 	addr string,
 ) (net.Conn, error) {
-	// Prevent concurrency to avoid intermixing requests and responses
-	localNetworkHelper.mtx.Lock()
-	defer localNetworkHelper.mtx.Unlock()
+	// Check for global local network error first
+	if err := localNetworkHelper.err.Load(); err != nil {
+		return nil, *err
+	}
 
-	privilegedSocketRequest := PrivilegedSocketRequest{
+	replyCh := make(chan Reply, 1)
+
+	localNetworkHelper.requestsUnprocessed <- Request{
 		Network: network,
 		Addr:    addr,
+		ReplyCh: replyCh,
 	}
 
-	privilegedSocketRequestJSONBytes, err := json.Marshal(&privilegedSocketRequest)
-	if err != nil {
-		return nil, err
+	select {
+	case reply := <-replyCh:
+		return reply.Conn, reply.Err
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
+}
 
-	_, err = localNetworkHelper.unixConn.Write(privilegedSocketRequestJSONBytes)
-	if err != nil {
-		return nil, err
+func (localNetworkHelper *LocalNetworkHelper) handleRequests() {
+	for request := range localNetworkHelper.requestsUnprocessed {
+		privilegedSocketRequest := PrivilegedSocketRequest{
+			Token:   uuid.New().String(),
+			Network: request.Network,
+			Addr:    request.Addr,
+		}
+
+		privilegedSocketRequestJSONBytes, err := json.Marshal(&privilegedSocketRequest)
+		if err != nil {
+			request.ReplyCh <- Reply{
+				Err: fmt.Errorf("failed to marshal privileged socket request: %v", err),
+			}
+
+			continue
+		}
+
+		// We need mark the request as processed before we send it,
+		// otherwise the handleResponses() will trip up because it
+		// won't be able to find this request
+		localNetworkHelper.requestsProcessed.Store(privilegedSocketRequest.Token, request)
+
+		_, err = localNetworkHelper.unixConn.Write(privilegedSocketRequestJSONBytes)
+		if err != nil {
+			// Unmark the request as processed because send failed
+			localNetworkHelper.requestsProcessed.Delete(privilegedSocketRequest.Token)
+
+			request.ReplyCh <- Reply{
+				Err: fmt.Errorf("failed to send privileged socket request: %v", err),
+			}
+		}
 	}
+}
 
+func (localNetworkHelper *LocalNetworkHelper) handleResponses() {
 	buf := make([]byte, 4096)
 	oob := make([]byte, 4096)
 
-	n, oobn, _, _, err := localNetworkHelper.unixConn.ReadMsgUnix(buf, oob)
-	if err != nil {
-		return nil, err
+	for {
+		n, oobn, _, _, err := localNetworkHelper.unixConn.ReadMsgUnix(buf, oob)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+
+			err = fmt.Errorf("failed to read from the local network helper: %w", err)
+
+			localNetworkHelper.err.CompareAndSwap(nil, &err)
+
+			return
+		}
+
+		// Parse response(s)
+		decoder := json.NewDecoder(bytes.NewReader(buf[:n]))
+
+		for {
+			var privilegedSocketResponse PrivilegedSocketResponse
+
+			if err := decoder.Decode(&privilegedSocketResponse); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				err = fmt.Errorf("failed to unmarshal privileged socket response: %w", err)
+
+				localNetworkHelper.err.CompareAndSwap(nil, &err)
+
+				return
+			}
+
+			processedRequest, ok := localNetworkHelper.requestsProcessed.LoadAndDelete(privilegedSocketResponse.Token)
+			if !ok {
+				err := fmt.Errorf("got response for a non-existent request %q", privilegedSocketResponse.Token)
+
+				localNetworkHelper.err.CompareAndSwap(nil, &err)
+
+				return
+			}
+
+			netConn, err := handleResponse(privilegedSocketResponse, oob, oobn)
+			processedRequest.ReplyCh <- Reply{
+				Conn: netConn,
+				Err:  err,
+			}
+		}
 	}
+}
 
-	var privilegedSocketResponse PrivilegedSocketResponse
-
-	if err := json.Unmarshal(buf[:n], &privilegedSocketResponse); err != nil {
-		return nil, err
-	}
-
+func handleResponse(privilegedSocketResponse PrivilegedSocketResponse, oob []byte, oobn int) (net.Conn, error) {
 	if privilegedSocketResponse.Error != "" {
 		return nil, fmt.Errorf("%s", privilegedSocketResponse.Error)
 	}
 
 	socketControlMessages, err := unix.ParseSocketControlMessage(oob[:oobn])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse socket control message: %w", err)
 	}
 
 	if len(socketControlMessages) != 1 {
@@ -177,13 +282,19 @@ func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
 
 	netConn, err := net.FileConn(netFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to convert netFile to netConn: %w", err)
 	}
 
-	// We can safely close the unixRights[0] now as it was dup(2)'ed by the net.FileConn
+	// We can safely close the netFile now as it was dup(2)'ed by the net.FileConn
 	if err := netFile.Close(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to close netFile: %w", err)
 	}
 
 	return netConn, nil
+}
+
+func (localNetworkHelper *LocalNetworkHelper) Close() error {
+	close(localNetworkHelper.requestsUnprocessed)
+
+	return localNetworkHelper.unixConn.Close()
 }

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -8,7 +8,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -42,19 +44,69 @@ func TestLocalNetworkHelper(t *testing.T) {
 		},
 	}
 
-	respExample, err := httpClient.Get("https://example.com/")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, respExample.StatusCode)
+	var wg sync.WaitGroup
 
-	respCirrus, err := httpClient.Get("https://cirrus-ci.org/")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, respCirrus.StatusCode)
+	wg.Add(3)
 
-	exampleBytes, err := io.ReadAll(respExample.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(exampleBytes), "Example Domain")
+	go func() {
+		defer wg.Done()
 
-	cirrusBytes, err := io.ReadAll(respCirrus.Body)
+		respExample, err := httpClient.Get("https://example.com/")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respExample.StatusCode)
+
+		exampleBytes, err := io.ReadAll(respExample.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(exampleBytes), "Example Domain")
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		respCirrus, err := httpClient.Get("https://cirrus-ci.org/")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respCirrus.StatusCode)
+
+		cirrusBytes, err := io.ReadAll(respCirrus.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(cirrusBytes), "Cirrus CI")
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		respCirrus, err := httpClient.Get("https://cirrus-runners.app/")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respCirrus.StatusCode)
+
+		cirrusBytes, err := io.ReadAll(respCirrus.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(cirrusBytes), "Cirrus Runners")
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, localNetworkHelper.Close())
+}
+
+func TestLocalNetworkHelperRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	localNetworkHelper, err := localnetworkhelper.New(ctx)
 	require.NoError(t, err)
-	require.Contains(t, string(cirrusBytes), "Cirrus CI")
+
+	boundedCtx, boundedCtxCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer boundedCtxCancel()
+
+	startedAt := time.Now()
+
+	// Try to connect to an address in non-routable TEST-NET-1[1]
+	//
+	// [1]: https://datatracker.ietf.org/doc/html/rfc5737#section-3
+	_, err = localNetworkHelper.PrivilegedDialContext(boundedCtx, "tcp", "192.0.2.1:80")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.InDelta(t, 3.0, time.Since(startedAt).Seconds(), 0.5)
+
+	require.NoError(t, localNetworkHelper.Close())
 }


### PR DESCRIPTION
This is an alternative approach to https://github.com/cirruslabs/chacha/pull/21, which was reverted in https://github.com/cirruslabs/chacha/pull/24 because very connection close detection was almost impossible.

This keeps the `socketpair(2)` (which allows for easy connection close detection and thus helper process termination), yet unlocks the `PrivilegedDialContext()` and lets it obey `context.Context` by processing all of the requests and responses in separate goroutines.