### PR TITLE
Only cache URLs if they match at least one rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Chacha tries to build on:
 With the following exceptions:
 
 * Chacha is always validating: latency is traded for simplicity and security
-* For certain URLs, [you can specify `rules`](#rules-rules-optional) to override the default standard-like behavior, for example, you can:
+* Chacha will only consider caching of the URLs if it matches at least one entry in [`rules`](#rules-rules-optional)
+* [`rules`](#rules-rules-optional) allow to override the default standards-like behavior, for example, you can:
   * ignore the existence of `Authorization` header in the request for caching purposes
   * skip certain URL parameters (e.g. `X-Amz-Date` in S3 pre-signed URLs) from the cache key for caching purposes
 
@@ -79,7 +80,7 @@ tls-interceptor:
 
 ### Rules (`rules`, optional)
 
-Offers an escape hatch for violating RFC specifications for certain URLs.
+Defines URLs to consider caching and offers an escape hatch for violating RFC specifications for these URLs.
 
 #### Structure
 

--- a/internal/server/rule/rule.go
+++ b/internal/server/rule/rule.go
@@ -27,26 +27,20 @@ func New(pattern string, ignoreAuthorizationHeader bool, ignoreParameters []stri
 	}, nil
 }
 
-func (rules Rules) IgnoreAuthorizationHeader(url string) bool {
-	for _, rule := range rules {
-		if !rule.re.MatchString(url) {
-			continue
-		}
-
-		return rule.ignoreAuthorizationHeader
-	}
-
-	return false
+func (rule Rule) IgnoreAuthorizationHeader() bool {
+	return rule.ignoreAuthorizationHeader
 }
 
-func (rules Rules) IgnoredParamters(url string) []string {
-	for _, rule := range rules {
-		if !rule.re.MatchString(url) {
-			continue
-		}
+func (rule Rule) IgnoredParameters() []string {
+	return rule.ignoreParameters
+}
 
-		return rule.ignoreParameters
+func (rules Rules) Get(url string) *Rule {
+	for _, rule := range rules {
+		if rule.re.MatchString(url) {
+			return &rule
+		}
 	}
 
-	return []string{}
+	return nil
 }

--- a/internal/server/server_cluster_test.go
+++ b/internal/server/server_cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cirruslabs/chacha/internal/config"
 	"github.com/cirruslabs/chacha/internal/server"
 	"github.com/cirruslabs/chacha/internal/server/cluster"
+	"github.com/cirruslabs/chacha/internal/server/rule"
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,13 @@ func TestCluster(t *testing.T) {
 	logger := zap.Must(zap.NewDevelopment())
 
 	// Configure first Chacha node, in cluster, without a disk
+	catchAllRule, err := rule.New(".*", false, []string{})
+	require.NoError(t, err)
+
 	firstOpts := []server.Option{
+		server.WithRules(rule.Rules{
+			catchAllRule,
+		}),
 		server.WithCluster(
 			cluster.New(
 				secret,


### PR DESCRIPTION
Tightens up the security by not caching random stuff not explicitly defined by us.