### PR TITLE
Replace speed_bytes_per_second histogram with transfer_bytes counter

### DIFF
--- a/internal/server/handle_proxy_default.go
+++ b/internal/server/handle_proxy_default.go
@@ -144,12 +144,12 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 		}
 
 		// Metrics
-		//nolint:contextcheck // can's use request.Context() here because it might be canceled
+		//nolint:contextcheck // can't use request.Context() here because it might be canceled
 		server.cacheOperationCounter.Add(context.Background(), 1, metric.WithAttributes(
 			attribute.String("type", "miss"),
 		))
 
-		//nolint:contextcheck // can's use request.Context() here because it might be canceled
+		//nolint:contextcheck // can't use request.Context() here because it might be canceled
 		server.cacheTransferCounter.Add(context.Background(), upstreamResponse.ContentLength, metric.WithAttributes(
 			attribute.String("type", "miss"),
 		))
@@ -167,12 +167,12 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 		}
 
 		// Metrics
-		//nolint:contextcheck // can's use request.Context() here because it might be canceled
+		//nolint:contextcheck // can't use request.Context() here because it might be canceled
 		server.cacheOperationCounter.Add(context.Background(), 1, metric.WithAttributes(
 			attribute.String("type", "hit"),
 		))
 
-		//nolint:contextcheck // can's use request.Context() here because it might be canceled
+		//nolint:contextcheck // can't use request.Context() here because it might be canceled
 		server.cacheTransferCounter.Add(context.Background(), n, metric.WithAttributes(
 			attribute.String("type", "hit"),
 		))
@@ -188,7 +188,7 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 		}
 
 		// Metrics
-		//nolint:contextcheck // can's use request.Context() here because it might be canceled
+		//nolint:contextcheck // can't use request.Context() here because it might be canceled
 		server.cacheOperationCounter.Add(context.Background(), 1, metric.WithAttributes(
 			attribute.String("type", "not-allowed"),
 		))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,7 +40,7 @@ type Server struct {
 	// Metrics
 	requestsCounter       metric.Int64Counter
 	cacheOperationCounter metric.Int64Counter
-	cacheSpeedHistogram   metric.Int64Histogram
+	cacheTransferCounter  metric.Int64Counter
 }
 
 func New(addr string, opts ...Option) (*Server, error) {
@@ -116,8 +116,8 @@ func New(addr string, opts ...Option) (*Server, error) {
 		return nil, err
 	}
 
-	server.cacheSpeedHistogram, err = opentelemetry.DefaultMeter.Int64Histogram(
-		"org.cirruslabs.chacha.cache.speed_bytes_per_second",
+	server.cacheTransferCounter, err = opentelemetry.DefaultMeter.Int64Counter(
+		"org.cirruslabs.chacha.cache.transfer_bytes",
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Histogram needs to be tuned in order to be useful.

And with counter, we can easily find the speed by using [`rate()`](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate).