### PR TITLE
Make direct connect header optional

### DIFF
--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -98,7 +98,7 @@ func run(cmd *cobra.Command, _ []string) error {
 
 		for _, configMatch := range config.Rules {
 			rule, err := rule.New(configMatch.Pattern, configMatch.IgnoreAuthorizationHeader,
-				configMatch.IgnoreParameters, configMatch.DirectConnect)
+				configMatch.IgnoreParameters, configMatch.DirectConnect, configMatch.DirectConnectHeader)
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Rule struct {
 	IgnoreAuthorizationHeader bool     `yaml:"ignore-authorization-header"`
 	IgnoreParameters          []string `yaml:"ignore-parameters"`
 	DirectConnect             bool     `yaml:"direct-connect"`
+	DirectConnectHeader       bool     `yaml:"direct-connect-header"`
 }
 
 type Cluster struct {

--- a/internal/server/handle_proxy_default.go
+++ b/internal/server/handle_proxy_default.go
@@ -181,7 +181,9 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 
 			// Provide a direct connect hint so that the client
 			// can disable the proxy server for faster retrieval
-			writer.Header().Set("X-Chacha-Direct-Connect", "1")
+			if rule.DirectConnectHeader() {
+				writer.Header().Set("X-Chacha-Direct-Connect", "1")
+			}
 
 			return responder.NewCodef(http.StatusTemporaryRedirect, "redirected with a direct connect hint")
 		}

--- a/internal/server/rule/rule.go
+++ b/internal/server/rule/rule.go
@@ -12,9 +12,16 @@ type Rule struct {
 	ignoreAuthorizationHeader bool
 	ignoreParameters          []string
 	directConnect             bool
+	directConnectHeader       bool
 }
 
-func New(pattern string, ignoreAuthorizationHeader bool, ignoreParameters []string, directConnect bool) (Rule, error) {
+func New(
+	pattern string,
+	ignoreAuthorizationHeader bool,
+	ignoreParameters []string,
+	directConnect bool,
+	directConnectHeader bool,
+) (Rule, error) {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return Rule{}, fmt.Errorf("failed to parse regular expression for path pattern %s: %w",
@@ -26,6 +33,7 @@ func New(pattern string, ignoreAuthorizationHeader bool, ignoreParameters []stri
 		ignoreAuthorizationHeader: ignoreAuthorizationHeader,
 		ignoreParameters:          ignoreParameters,
 		directConnect:             directConnect,
+		directConnectHeader:       directConnectHeader,
 	}, nil
 }
 
@@ -39,6 +47,10 @@ func (rule Rule) IgnoredParameters() []string {
 
 func (rule Rule) DirectConnect() bool {
 	return rule.directConnect
+}
+
+func (rule Rule) DirectConnectHeader() bool {
+	return rule.directConnectHeader
 }
 
 func (rules Rules) Get(url string) *Rule {

--- a/internal/server/rule/rule_test.go
+++ b/internal/server/rule/rule_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNewLineIsCounteredByUsingBeginningAndEnd(t *testing.T) {
 	simpleRule, err := rulepkg.New("^.*.good.com$",
-		true, []string{"doesn't matter"}, false)
+		true, []string{"doesn't matter"}, false, false)
 	require.NoError(t, err)
 
 	rules := rulepkg.Rules{simpleRule}
@@ -18,7 +18,7 @@ func TestNewLineIsCounteredByUsingBeginningAndEnd(t *testing.T) {
 
 func TestFirstMatchWins(t *testing.T) {
 	matchGranular, err := rulepkg.New("https://cirrus-ci.com/task/[0-9]+",
-		true, []string{"X-Granular"}, false)
+		true, []string{"X-Granular"}, false, false)
 	require.NoError(t, err)
 
 	rules := rulepkg.Rules{matchGranular}
@@ -26,7 +26,7 @@ func TestFirstMatchWins(t *testing.T) {
 	require.NotNil(t, rule)
 
 	matchCoarse, err := rulepkg.New(`https://cirrus-ci.com/.*`,
-		true, []string{"X-Coarse"}, false)
+		true, []string{"X-Coarse"}, false, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"X-Granular"}, rule.IgnoredParameters())
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,6 +113,16 @@ func New(addr string, opts ...Option) (*Server, error) {
 				DialContext: server.localNetworkHelper.PrivilegedDialContext,
 			},
 		}
+
+		// We need this when using direct connect functionality
+		// with direct connect header disabled
+		server.externalHTTPClient = &http.Client{
+			Transport: &http.Transport{
+				DialContext: server.localNetworkHelper.PrivilegedDialContext,
+
+				DisableCompression: true,
+			},
+		}
 	}
 
 	// Metrics

--- a/internal/server/server_cluster_test.go
+++ b/internal/server/server_cluster_test.go
@@ -26,7 +26,8 @@ func TestCluster(t *testing.T) {
 	logger := zap.Must(zap.NewDevelopment())
 
 	// Configure first Chacha node, in cluster, without a disk
-	catchAllRule, err := rule.New(".*", false, []string{}, false)
+	catchAllRule, err := rule.New(".*", false, []string{}, false,
+		false)
 	require.NoError(t, err)
 
 	firstOpts := []server.Option{


### PR DESCRIPTION
To handle a case when direct connection is not possible, but lack of TLS overhead is desired.