### PR TITLE
Enable OpenTelemetry context propagation via W3C Trace Context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
+	github.com/deckarep/golang-set/v2 v2.8.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
+github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/internal/opentelemetry/opentelemetry.go
+++ b/internal/opentelemetry/opentelemetry.go
@@ -86,7 +86,7 @@ func Init(ctx context.Context) (zapcore.Core, func(), error) {
 	otel.SetTracerProvider(traceProvider)
 
 	// Enable context propagation via W3C Trace Context automatically
-	// when using helpers like otelhttp.NewHandler() and manuall
+	// when using helpers like otelhttp.NewHandler() and manually
 	// when calling otel.GetTextMapPropagator()'s methods
 	// like Extract() and Inject()
 	otel.SetTextMapPropagator(propagation.TraceContext{})

--- a/internal/opentelemetry/opentelemetry.go
+++ b/internal/opentelemetry/opentelemetry.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/log/global"
+	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
@@ -83,6 +84,12 @@ func Init(ctx context.Context) (zapcore.Core, func(), error) {
 		_ = traceProvider.Shutdown(ctx)
 	})
 	otel.SetTracerProvider(traceProvider)
+
+	// Enable context propagation via W3C Trace Context automatically
+	// when using helpers like otelhttp.NewHandler() and manuall
+	// when calling otel.GetTextMapPropagator()'s methods
+	// like Extract() and Inject()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	// Logs
 	logExporter, err := otlploghttp.New(ctx)

--- a/internal/server/cluster/cluster_test.go
+++ b/internal/server/cluster/cluster_test.go
@@ -45,3 +45,14 @@ func TestClusterStabilityRemove(t *testing.T) {
 
 	require.Equal(t, cluster1.TargetNode("test"), cluster2.TargetNode("test"))
 }
+
+func TestClusterContainsNode(t *testing.T) {
+	cluster := cluster.New("doesn't matter", "whatever", []config.Node{
+		{Addr: "192.168.0.1"},
+		{Addr: "192.168.0.2"},
+		{Addr: "192.168.0.3"},
+	})
+
+	require.True(t, cluster.ContainsNode("192.168.0.2"))
+	require.False(t, cluster.ContainsNode("192.168.0.4"))
+}

--- a/internal/server/handle_proxy_default.go
+++ b/internal/server/handle_proxy_default.go
@@ -117,7 +117,7 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 	// Determine the HTTP client to use
 	var httpClient *http.Client
 
-	if server.cluster.ContainsNode(upstreamRequest.URL.Host) {
+	if server.cluster != nil && server.cluster.ContainsNode(upstreamRequest.URL.Host) {
 		httpClient = server.internalHTTPClient
 	} else {
 		httpClient = server.externalHTTPClient

--- a/internal/server/handle_proxy_default.go
+++ b/internal/server/handle_proxy_default.go
@@ -114,8 +114,17 @@ func (server *Server) handleProxyDefault(writer http.ResponseWriter, request *ht
 
 	server.logger.Debugf("upstream request: %+v", upstreamRequest)
 
+	// Determine the HTTP client to use
+	var httpClient *http.Client
+
+	if server.cluster.ContainsNode(upstreamRequest.URL.Host) {
+		httpClient = server.internalHTTPClient
+	} else {
+		httpClient = server.externalHTTPClient
+	}
+
 	// Perform an upstream request
-	upstreamResponse, err := server.externalHTTPClient.Do(upstreamRequest)
+	upstreamResponse, err := httpClient.Do(upstreamRequest)
 	if err != nil {
 		return responder.NewCodef(http.StatusInternalServerError, "failed to perform a request "+
 			"to the upstream: %v", err)


### PR DESCRIPTION
Context is picked up by `otelhttp.NewHandler()` on each request and propagated further with `otelhttp.NewTransport()` when using `internalHTTPClient`.

Tested with:

```shell
curl --proxy 'http://127.0.0.1:8080' --header 'traceparent: 00-11111111111111111111111111111111-2222222222222222-01' 'http://example.com'
```