### PR TITLE
Periodically perform cluster health checks

### DIFF
--- a/internal/server/cluster/cluster.go
+++ b/internal/server/cluster/cluster.go
@@ -46,3 +46,7 @@ func (cluster *Cluster) TargetNode(key string) string {
 func (cluster *Cluster) ContainsNode(node string) bool {
 	return cluster.nodes.ContainsOne(node)
 }
+
+func (cluster *Cluster) Nodes() []string {
+	return cluster.nodes.ToSlice()
+}

--- a/internal/server/cluster_health.go
+++ b/internal/server/cluster_health.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+const clusterHealthCheckTimeout = 5 * time.Second
+
+func (server *Server) clusterHealthCallback(ctx context.Context, observer metric.Int64Observer) error {
+	type Result struct {
+		Node    string
+		Healthy bool
+	}
+
+	nodes := server.cluster.Nodes()
+	results := make(chan Result, len(nodes))
+
+	var wg sync.WaitGroup
+
+	for _, node := range nodes {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			results <- Result{
+				Node:    node,
+				Healthy: server.clusterNodeIsHealthy(ctx, node),
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		var value int64
+
+		if result.Healthy {
+			value = 1
+		} else {
+			value = 0
+		}
+
+		observer.Observe(value, metric.WithAttributes(
+			attribute.String("node", result.Node),
+		))
+	}
+
+	return nil
+}
+
+func (server *Server) clusterNodeIsHealthy(ctx context.Context, node string) bool {
+	boundedCtx, cancel := context.WithTimeout(ctx, clusterHealthCheckTimeout)
+	defer cancel()
+
+	nodeURL := url.URL{
+		Scheme: "http",
+		Host:   node,
+		Path:   "/health",
+	}
+
+	req, err := http.NewRequestWithContext(boundedCtx, "GET", nodeURL.String(), nil)
+	if err != nil {
+		server.logger.Warnf("failed to perform health check of the cluster node %s: "+
+			"failed to create HTTP request: %v", node, err)
+
+		return false
+	}
+
+	resp, err := server.internalHTTPClient.Do(req)
+	if err != nil {
+		server.logger.Warnf("failed to perform health check of the cluster node %s: "+
+			"failed to perform HTTP request: %v", node, err)
+
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		server.logger.Warnf("failed to perform health check of the cluster node %s: "+
+			"expected HTTP %d, got HTTP %d", node, http.StatusOK, resp.StatusCode)
+
+		return false
+	}
+
+	return true
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,6 +160,14 @@ func New(addr string, opts ...Option) (*Server, error) {
 		return nil, err
 	}
 
+	if server.cluster != nil {
+		_, err = opentelemetry.DefaultMeter.Int64ObservableGauge("org.cirruslabs.chacha.cluster.health",
+			metric.WithInt64Callback(server.clusterHealthCallback))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return server, nil
 }
 


### PR DESCRIPTION
And publish them as `org.cirruslabs.chacha.cluster.health` metric.