### PR TITLE
Make localnetworkhelper package compileable on all platforms

### DIFF
--- a/pkg/localnetworkhelper/common.go
+++ b/pkg/localnetworkhelper/common.go
@@ -1,0 +1,6 @@
+package localnetworkhelper
+
+import "errors"
+
+//nolint:staticcheck // it's OK to capitalize "Local Network" in this error
+var ErrUnsupportedPlatform = errors.New("Local Network permission helper is not supported on this platform")

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package localnetworkhelper
 
 import (

--- a/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
@@ -1,0 +1,26 @@
+//go:build !unix
+
+package localnetworkhelper
+
+import (
+	"context"
+	"net"
+)
+
+type LocalNetworkHelper struct{}
+
+func New(ctx context.Context) (*LocalNetworkHelper, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func (localNetworkHelper *LocalNetworkHelper) PrivilegedDialContext(
+	_ context.Context,
+	_ string,
+	_ string,
+) (net.Conn, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func (localNetworkHelper *LocalNetworkHelper) Close() error {
+	return ErrUnsupportedPlatform
+}

--- a/pkg/localnetworkhelper/serve.go
+++ b/pkg/localnetworkhelper/serve.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package localnetworkhelper
 
 import (

--- a/pkg/localnetworkhelper/serve_unsupported.go
+++ b/pkg/localnetworkhelper/serve_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package localnetworkhelper
+
+func Serve(_ int) error {
+	return ErrUnsupportedPlatform
+}


### PR DESCRIPTION
This simplifies integrating with `localnetworkhelper` for software like Cirrus CLI that targets not only macOS, but other non-Unix platforms too.

Otherwise it's not possible to easily pass `*localnetworkhelper.LocalNetworkHelper` around, even if it's `nil`, because it results in compilation error.